### PR TITLE
Create $HOME/.local folder in case it does not exist

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -129,6 +129,7 @@ runs:
               ;;
           esac
 
+          mkdir -p "$HOME"/.local
           cd "$HOME"/.local
 
           url="https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-$os-$arch/$version/embedded-postgres-binaries-$os-$arch-$version.jar"


### PR DESCRIPTION
New ubuntu-latest runners (22.04) don't have $HOME/.local by default.

Fixes #3.